### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ packaging
 scipy
 argparse
 PyYAML
-scikit-image
+scikit-image==0.19


### PR DESCRIPTION
### Scikit-image version should be set, because the latest version will lead to a "ValueError" issue while training.

Scikit-image v0.20 contains this [commit](https://github.com/scikit-image/scikit-image/commit/db55f3862d4a6deb0552305c4365401faa896bea) which would raise ValueError while caculating SSIM at the end of epoch.

Here is the backtrace of the issue
```shell
(naf) ➜  naf_cbct git:(main) python train.py --config ./config/chest_50.yaml

/environment/miniconda3/envs/naf/lib/python3.9/site-packages/torch/functional.py:568: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at  ../aten/src/ATen/native/TensorShape.cpp:2228.)
  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]
[Start] exp: chest_50, net: Basic network
epoch=0/1500, loss=0.000609, lr=0.001: :  98% 49/50 [00:00<00:00, 84.86it/s]Traceback (most recent call last):
  File "/home/featurize/work/Reconstruction/naf_cbct/train.py", line 100, in <module>
    trainer.start()
  File "/home/featurize/work/Reconstruction/naf_cbct/src/trainer.py", line 108, in start
    loss_test = self.eval_step(global_step=self.global_step)
  File "/home/featurize/work/Reconstruction/naf_cbct/train.py", line 76, in eval_step
    'ssim_3d': get_ssim_3d(image_pred, image),
  File "/home/featurize/work/Reconstruction/naf_cbct/src/util/util.py", line 85, in get_ssim_3d
    ssim = structural_similarity(arr1_d[i], arr2_d[i])
  File "/environment/miniconda3/envs/naf/lib/python3.9/site-packages/skimage/metrics/_structural_similarity.py", line 194, in structural_similarity
    raise ValueError(
ValueError: Since image dtype is floating point, you must specify the data_range parameter. Please read the documentation carefully (including the note). It is recommended that you always specify the data_range anyway.
(naf) ➜  naf_cbct git:(main) 
```